### PR TITLE
Add teacher update and delete APIs

### DIFF
--- a/src/main/java/cn/edu/qvtu/api/KaoShiApi.java
+++ b/src/main/java/cn/edu/qvtu/api/KaoShiApi.java
@@ -46,4 +46,20 @@ public class KaoShiApi {
         //编写业务逻辑
         return kaoShiService.addTeacher(data);
     }
+
+    //根据工号修改教师API
+    @PostMapping("/api/teacher/update")
+    @ResponseBody
+    public ApiData update(@RequestBody Teacher data){
+        //编写业务逻辑
+        return kaoShiService.updateTeacher(data);
+    }
+
+    //根据工号删除教师API
+    @GetMapping("/api/teacher/delete/{gh}")
+    @ResponseBody
+    public ApiData delete(@PathVariable String gh){
+        //编写业务逻辑
+        return kaoShiService.deleteTeacherById(gh);
+    }
 }

--- a/src/main/java/cn/edu/qvtu/mapper/KaoShiMapper.java
+++ b/src/main/java/cn/edu/qvtu/mapper/KaoShiMapper.java
@@ -18,4 +18,8 @@ public interface KaoShiMapper {
     List<Teacher> getTeacherByGh(String gh);
 
     int addTeacher(Teacher teacher);
+
+    int updateTeacher(Teacher teacher);
+
+    int deleteTeacher(String gh);
 }

--- a/src/main/java/cn/edu/qvtu/service/KaoShiService.java
+++ b/src/main/java/cn/edu/qvtu/service/KaoShiService.java
@@ -16,4 +16,8 @@ public interface KaoShiService {
     ApiData getTeacherById(String id);
 
     ApiData addTeacher(Teacher teacher);
+
+    ApiData updateTeacher(Teacher teacher);
+
+    ApiData deleteTeacherById(String id);
 }

--- a/src/main/java/cn/edu/qvtu/service/impl/KaoShiServiceImpl.java
+++ b/src/main/java/cn/edu/qvtu/service/impl/KaoShiServiceImpl.java
@@ -76,4 +76,36 @@ public class KaoShiServiceImpl implements KaoShiService {
         }
         return ApiData.fail("添加失败");
     }
+
+    @Override
+    public ApiData updateTeacher(Teacher teacher) {
+        if (teacher == null) {
+            return ApiData.fail("数据为空");
+        }
+        if (StringUtils.isEmpty(teacher.getGh())) {
+            return ApiData.fail("工号必填");
+        }
+        if (StringUtils.isEmpty(teacher.getXm())) {
+            return ApiData.fail("姓名必填");
+        }
+        //更新教师信息(这里做数据库操作）
+        int i = kaoShiMapper.updateTeacher(teacher);
+        if (i > 0) {
+            return ApiData.success(i, "修改成功");
+        }
+        return ApiData.fail("修改失败");
+    }
+
+    @Override
+    public ApiData deleteTeacherById(String id) {
+        if (StringUtils.isEmpty(id)) {
+            return ApiData.fail("工号必填");
+        }
+        //删除教师信息(这里做数据库操作）
+        int i = kaoShiMapper.deleteTeacher(id);
+        if (i > 0) {
+            return ApiData.success(i, "删除成功");
+        }
+        return ApiData.fail("删除失败");
+    }
 }

--- a/src/main/resources/mapper/KaoShiMapper.xml
+++ b/src/main/resources/mapper/KaoShiMapper.xml
@@ -16,4 +16,14 @@
     <select id="getTeacherByGh" resultType="cn.edu.qvtu.pojo.Teacher">
         select * from teacher where gh=#{gh}
     </select>
+
+    <update id="updateTeacher">
+        update teacher
+        set xm=#{xm}, sj=#{sj}
+        where gh=#{gh}
+    </update>
+
+    <delete id="deleteTeacher">
+        delete from teacher where gh=#{gh}
+    </delete>
 </mapper>


### PR DESCRIPTION
## Summary
- add update and delete API endpoints for teachers
- expose updateTeacher and deleteTeacher methods in service layer
- implement mapper methods and SQL for update and delete

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abb64c9e48322b69b1d6e8f9a17a7